### PR TITLE
Keep a rewind history to pick references from

### DIFF
--- a/python/src/ytpb_mpv/cli.py
+++ b/python/src/ytpb_mpv/cli.py
@@ -1,211 +1,22 @@
 import atexit
 import shutil
 from copy import deepcopy
-from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
-from tempfile import NamedTemporaryFile
-from typing import Self, TypeGuard
-from xml.etree import ElementTree
 
 import click
 import cloup
 import structlog
 from cloup.constraints import constraint, require_any
-from python_mpv_jsonipc import MPV
 
-from ytpb.actions.compose import compose_dynamic_mpd
 from ytpb.cli import base_cli
 from ytpb.cli.common import create_playback, query_streams_or_exit, stream_argument
 from ytpb.cli.options import cache_options, yt_dlp_option
 from ytpb.cli.parameters import FormatSpecParamType, FormatSpecType
-from ytpb.locate import SegmentLocator
-from ytpb.playback import Playback
-from ytpb.segment import SegmentMetadata
 from ytpb.streams import Streams
-from ytpb.types import SegmentSequence, SetOfStreams, Timestamp
-from ytpb.utils.remote import request_reference_sequence
+
+from ytpb_mpv.listener import Listener
 
 logger = structlog.get_logger(__name__)
-
-YTPB_CLIENT_NAME = "yp"
-
-
-@dataclass
-class TreeNode:
-    key: Timestamp
-    value: SegmentSequence
-    left: Self | None = None
-    right: Self | None = None
-
-
-@dataclass
-class TreeMap:
-    """A binary search tree implementation to store key-value pairs.
-
-    Keys represent timestamps of segments, while values are sequence numbers.
-    """
-
-    root: TreeNode | None = None
-
-    @staticmethod
-    def _is_tree_node(node: TreeNode | None) -> TypeGuard[TreeNode]:
-        return node is not None
-
-    @staticmethod
-    def _insert(
-        node: TreeNode | None, key: Timestamp, value: SegmentSequence
-    ) -> TreeNode:
-        if not TreeMap._is_tree_node(node):
-            return TreeNode(key, value, None, None)
-        else:
-            if key < node.key:
-                left = TreeMap._insert(node.left, key, value)
-                return TreeNode(node.key, node.value, left, node.right)
-            elif key > node.key:
-                right = TreeMap._insert(node.right, key, value)
-                return TreeNode(node.key, node.value, node.left, right)
-            else:
-                return TreeNode(node.key, value, node.left, node.right)
-
-    def insert(self, key: Timestamp, value: SegmentSequence) -> None:
-        """Insert a pair of timestamp and sequence number into the tree."""
-        self.root = TreeMap._insert(self.root, key, value)
-
-    @staticmethod
-    def _closest(
-        node: TreeNode | None, target: Timestamp, closest: TreeNode
-    ) -> TreeNode | None:
-        if not TreeMap._is_tree_node(node):
-            return closest
-        else:
-            result = closest
-            if abs(target - closest.key) > abs(target - node.key):
-                result = node
-            if target < node.key:
-                return TreeMap._closest(node.left, target, result)
-            elif target > node.key:
-                return TreeMap._closest(node.right, target, result)
-            else:
-                return result
-
-    def closest(self, target: Timestamp) -> TreeNode | None:
-        """Find the node closest to the target timestamp."""
-        if self.root is None:
-            return None
-        return TreeMap._closest(self.root, target, self.root)
-
-
-class Listener:
-    def __init__(
-        self, ipc_server: Path, playback: Playback, streams: SetOfStreams
-    ) -> None:
-        self._playback = playback
-        self._streams = streams
-        self._mpd_path: Path | None = None
-        self._mpd_start_time: datetime | None = None
-
-        self._mpv = MPV(start_mpv=False, ipc_socket=str(ipc_server))
-        self._mpv.bind_event("client-message", self._client_message_handler)
-
-        self.rewind_tree = TreeMap()
-
-    def _client_message_handler(self, event: dict) -> None:
-        logger.debug(event)
-        try:
-            targeted_command, *args = event["args"]
-            target, command = targeted_command.split(":")
-        except ValueError:
-            return
-        else:
-            if target != YTPB_CLIENT_NAME:
-                return
-
-        match command:
-            case "rewind":
-                try:
-                    (rewind_value,) = args
-                    self.handle_rewind(datetime.fromisoformat(rewind_value))
-                except ValueError:
-                    pass
-
-    def _compose_mpd(
-        self, rewind_segment_metadata: SegmentMetadata
-    ) -> tuple[Path, datetime]:
-        mpd = compose_dynamic_mpd(
-            self._playback, rewind_segment_metadata, self._streams
-        )
-        with NamedTemporaryFile(
-            "w",
-            prefix="ytpb-",
-            suffix=".mpd",
-            dir=self._playback.get_temp_directory(),
-            delete=False,
-        ) as f:
-            f.write(mpd)
-            mpd_path = Path(f.name)
-            logger.debug("Saved playback MPD file to %s", mpd_path)
-
-        mpd_etree = ElementTree.fromstring(mpd)
-        mpd_start_time_string = mpd_etree.attrib["availabilityStartTime"]
-        mpd_start_time = datetime.fromisoformat(mpd_start_time_string)
-        logger.debug("MPD@availabilityStartTime=%s", mpd_start_time_string)
-
-        return mpd_path, mpd_start_time
-
-    def handle_rewind(self, target_date: datetime) -> None:
-        some_base_url = next(iter(self._streams)).base_url
-
-        target = target_date.timestamp()
-        if reference := self.rewind_tree.closest(target):
-            reference_sequence = reference.value
-        else:
-            reference_sequence = None
-
-        print("***", reference_sequence)
-
-        sl = SegmentLocator(
-            some_base_url,
-            reference_sequence=reference_sequence,
-            temp_directory=self._playback.get_temp_directory(),
-            session=self._playback.session,
-        )
-        sequence, falls_into_gap = sl.find_sequence_by_time(target)
-        rewound_segment = self._playback.get_downloaded_segment(sequence, some_base_url)
-        target_date_diff = target_date - rewound_segment.ingestion_start_date
-
-        self.rewind_tree.insert(rewound_segment.metadata.ingestion_walltime, sequence)
-
-        self._mpd_path, self._mpd_start_time = self._compose_mpd(
-            rewound_segment.metadata
-        )
-
-        self._mpv.command("loadfile", str(self._mpd_path))
-        self._mpv.command("set_property", "pause", "yes")
-        self._mpv.command(
-            "script-message",
-            "yp:rewind-completed",
-            str(self._mpd_path),
-            str(target_date_diff.total_seconds()),
-        )
-
-    def start(self) -> None:
-        some_base_url = next(iter(self._streams)).base_url
-
-        latest_sequence = request_reference_sequence(
-            some_base_url, self._playback.session
-        )
-        latest_segment = self._playback.get_downloaded_segment(
-            latest_sequence, some_base_url
-        )
-        self.rewind_tree.insert(
-            latest_segment.metadata.ingestion_walltime, latest_sequence
-        )
-
-        self._mpd_path, self._mpd_start_time = self._compose_mpd(
-            latest_segment.metadata
-        )
-        self._mpv.command("loadfile", str(self._mpd_path))
 
 
 @cloup.command("listen", help="Start listening to mpv messages.")
@@ -275,5 +86,5 @@ def listen(
 
 
 cli = deepcopy(base_cli)
-
+cli.help = "A socket listener for mpv messages"
 cli.add_command(listen)

--- a/python/src/ytpb_mpv/listener.py
+++ b/python/src/ytpb_mpv/listener.py
@@ -1,0 +1,195 @@
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Self, TypeGuard
+from xml.etree import ElementTree
+
+import structlog
+from python_mpv_jsonipc import MPV
+
+from ytpb.actions.compose import compose_dynamic_mpd
+from ytpb.locate import SegmentLocator
+from ytpb.playback import Playback
+from ytpb.segment import SegmentMetadata
+from ytpb.types import SegmentSequence, SetOfStreams, Timestamp
+from ytpb.utils.remote import request_reference_sequence
+
+logger = structlog.get_logger(__name__)
+
+YTPB_CLIENT_NAME = "yp"
+
+
+@dataclass
+class TreeNode:
+    key: Timestamp
+    value: SegmentSequence
+    left: Self | None = None
+    right: Self | None = None
+
+
+@dataclass
+class TreeMap:
+    """A binary search tree implementation to store key-value pairs.
+
+    Keys represent timestamps of segments, while values are sequence numbers.
+    """
+
+    root: TreeNode | None = None
+
+    @staticmethod
+    def _is_tree_node(node: TreeNode | None) -> TypeGuard[TreeNode]:
+        return node is not None
+
+    @staticmethod
+    def _insert(
+        node: TreeNode | None, key: Timestamp, value: SegmentSequence
+    ) -> TreeNode:
+        if not TreeMap._is_tree_node(node):
+            return TreeNode(key, value, None, None)
+        else:
+            if key < node.key:
+                left = TreeMap._insert(node.left, key, value)
+                return TreeNode(node.key, node.value, left, node.right)
+            elif key > node.key:
+                right = TreeMap._insert(node.right, key, value)
+                return TreeNode(node.key, node.value, node.left, right)
+            else:
+                return TreeNode(node.key, value, node.left, node.right)
+
+    def insert(self, key: Timestamp, value: SegmentSequence) -> None:
+        """Insert a pair of timestamp and sequence number into the tree."""
+        self.root = TreeMap._insert(self.root, key, value)
+
+    @staticmethod
+    def _closest(
+        node: TreeNode | None, target: Timestamp, closest: TreeNode
+    ) -> TreeNode | None:
+        if not TreeMap._is_tree_node(node):
+            return closest
+        else:
+            result = closest
+            if abs(target - closest.key) > abs(target - node.key):
+                result = node
+            if target < node.key:
+                return TreeMap._closest(node.left, target, result)
+            elif target > node.key:
+                return TreeMap._closest(node.right, target, result)
+            else:
+                return result
+
+    def closest(self, target: Timestamp) -> TreeNode | None:
+        """Find the node closest to the target timestamp."""
+        if self.root is None:
+            return None
+        return TreeMap._closest(self.root, target, self.root)
+
+
+class Listener:
+    def __init__(
+        self, ipc_server: Path, playback: Playback, streams: SetOfStreams
+    ) -> None:
+        self._playback = playback
+        self._streams = streams
+        self._mpd_path: Path | None = None
+        self._mpd_start_time: datetime | None = None
+
+        self._mpv = MPV(start_mpv=False, ipc_socket=str(ipc_server))
+        self._mpv.bind_event("client-message", self._client_message_handler)
+
+        self.rewind_tree = TreeMap()
+
+    def _client_message_handler(self, event: dict) -> None:
+        logger.debug(event)
+        try:
+            targeted_command, *args = event["args"]
+            target, command = targeted_command.split(":")
+        except ValueError:
+            return
+        else:
+            if target != YTPB_CLIENT_NAME:
+                return
+
+        match command:
+            case "rewind":
+                try:
+                    (rewind_value,) = args
+                    self.handle_rewind(datetime.fromisoformat(rewind_value))
+                except ValueError:
+                    pass
+
+    def _compose_mpd(
+        self, rewind_segment_metadata: SegmentMetadata
+    ) -> tuple[Path, datetime]:
+        mpd = compose_dynamic_mpd(
+            self._playback, rewind_segment_metadata, self._streams
+        )
+        with NamedTemporaryFile(
+            "w",
+            prefix="ytpb-",
+            suffix=".mpd",
+            dir=self._playback.get_temp_directory(),
+            delete=False,
+        ) as f:
+            f.write(mpd)
+            mpd_path = Path(f.name)
+            logger.debug("Saved playback MPD file to %s", mpd_path)
+
+        mpd_etree = ElementTree.fromstring(mpd)
+        mpd_start_time_string = mpd_etree.attrib["availabilityStartTime"]
+        mpd_start_time = datetime.fromisoformat(mpd_start_time_string)
+        logger.debug("MPD@availabilityStartTime=%s", mpd_start_time_string)
+
+        return mpd_path, mpd_start_time
+
+    def handle_rewind(self, target_date: datetime) -> None:
+        some_base_url = next(iter(self._streams)).base_url
+
+        target = target_date.timestamp()
+        if reference := self.rewind_tree.closest(target):
+            reference_sequence = reference.value
+        else:
+            reference_sequence = None
+
+        sl = SegmentLocator(
+            some_base_url,
+            reference_sequence=reference_sequence,
+            temp_directory=self._playback.get_temp_directory(),
+            session=self._playback.session,
+        )
+        sequence, falls_into_gap = sl.find_sequence_by_time(target)
+        rewound_segment = self._playback.get_downloaded_segment(sequence, some_base_url)
+        target_date_diff = target_date - rewound_segment.ingestion_start_date
+
+        self.rewind_tree.insert(rewound_segment.metadata.ingestion_walltime, sequence)
+
+        self._mpd_path, self._mpd_start_time = self._compose_mpd(
+            rewound_segment.metadata
+        )
+
+        self._mpv.command("loadfile", str(self._mpd_path))
+        self._mpv.command("set_property", "pause", "yes")
+        self._mpv.command(
+            "script-message",
+            "yp:rewind-completed",
+            str(self._mpd_path),
+            str(target_date_diff.total_seconds()),
+        )
+
+    def start(self) -> None:
+        some_base_url = next(iter(self._streams)).base_url
+
+        latest_sequence = request_reference_sequence(
+            some_base_url, self._playback.session
+        )
+        latest_segment = self._playback.get_downloaded_segment(
+            latest_sequence, some_base_url
+        )
+        self.rewind_tree.insert(
+            latest_segment.metadata.ingestion_walltime, latest_sequence
+        )
+
+        self._mpd_path, self._mpd_start_time = self._compose_mpd(
+            latest_segment.metadata
+        )
+        self._mpv.command("loadfile", str(self._mpd_path))

--- a/python/src/ytpb_mpv/listener.py
+++ b/python/src/ytpb_mpv/listener.py
@@ -21,7 +21,7 @@ YTPB_CLIENT_NAME = "yp"
 
 
 @dataclass
-class TreeNode:
+class RewindTreeNode:
     key: Timestamp
     value: SegmentSequence
     left: Self | None = None
@@ -29,60 +29,60 @@ class TreeNode:
 
 
 @dataclass
-class TreeMap:
+class RewindTreeMap:
     """A binary search tree implementation to store key-value pairs.
 
     Keys represent timestamps of segments, while values are sequence numbers.
     """
 
-    root: TreeNode | None = None
+    root: RewindTreeNode | None = None
 
     @staticmethod
-    def _is_tree_node(node: TreeNode | None) -> TypeGuard[TreeNode]:
+    def _is_tree_node(node: RewindTreeNode | None) -> TypeGuard[RewindTreeNode]:
         return node is not None
 
     @staticmethod
     def _insert(
-        node: TreeNode | None, key: Timestamp, value: SegmentSequence
-    ) -> TreeNode:
-        if not TreeMap._is_tree_node(node):
-            return TreeNode(key, value, None, None)
+        node: RewindTreeNode | None, key: Timestamp, value: SegmentSequence
+    ) -> RewindTreeNode:
+        if not RewindTreeMap._is_tree_node(node):
+            return RewindTreeNode(key, value, None, None)
         else:
             if key < node.key:
-                left = TreeMap._insert(node.left, key, value)
-                return TreeNode(node.key, node.value, left, node.right)
+                left = RewindTreeMap._insert(node.left, key, value)
+                return RewindTreeNode(node.key, node.value, left, node.right)
             elif key > node.key:
-                right = TreeMap._insert(node.right, key, value)
-                return TreeNode(node.key, node.value, node.left, right)
+                right = RewindTreeMap._insert(node.right, key, value)
+                return RewindTreeNode(node.key, node.value, node.left, right)
             else:
-                return TreeNode(node.key, value, node.left, node.right)
+                return RewindTreeNode(node.key, value, node.left, node.right)
 
     def insert(self, key: Timestamp, value: SegmentSequence) -> None:
         """Insert a pair of timestamp and sequence number into the tree."""
-        self.root = TreeMap._insert(self.root, key, value)
+        self.root = RewindTreeMap._insert(self.root, key, value)
 
     @staticmethod
     def _closest(
-        node: TreeNode | None, target: Timestamp, closest: TreeNode
-    ) -> TreeNode | None:
-        if not TreeMap._is_tree_node(node):
+        node: RewindTreeNode | None, target: Timestamp, closest: RewindTreeNode
+    ) -> RewindTreeNode | None:
+        if not RewindTreeMap._is_tree_node(node):
             return closest
         else:
             result = closest
             if abs(target - closest.key) > abs(target - node.key):
                 result = node
             if target < node.key:
-                return TreeMap._closest(node.left, target, result)
+                return RewindTreeMap._closest(node.left, target, result)
             elif target > node.key:
-                return TreeMap._closest(node.right, target, result)
+                return RewindTreeMap._closest(node.right, target, result)
             else:
                 return result
 
-    def closest(self, target: Timestamp) -> TreeNode | None:
+    def closest(self, target: Timestamp) -> RewindTreeNode | None:
         """Find the node closest to the target timestamp."""
         if self.root is None:
             return None
-        return TreeMap._closest(self.root, target, self.root)
+        return RewindTreeMap._closest(self.root, target, self.root)
 
 
 class Listener:
@@ -97,7 +97,7 @@ class Listener:
         self._mpv = MPV(start_mpv=False, ipc_socket=str(ipc_server))
         self._mpv.bind_event("client-message", self._client_message_handler)
 
-        self.rewind_tree = TreeMap()
+        self.rewind_tree = RewindTreeMap()
 
     def _client_message_handler(self, event: dict) -> None:
         logger.debug(event)

--- a/ytpb.fnl
+++ b/ytpb.fnl
@@ -541,7 +541,9 @@ show the previously marked points."
 (fn on-load-file []
   (let [open-filename (mp.get_property :stream-open-filename "")]
     (if (= 1 (open-filename:find "ytpb://"))
-        (msg.info "ytpb URL detected, run hook" (run-hook open-filename)))))
+        (do
+          (msg.info "ytpb URL detected, run hook")
+          (run-hook open-filename)))))
 
 (mp.add_hook :on_load 50 on-load-file)
 

--- a/ytpb.lua
+++ b/ytpb.lua
@@ -18,6 +18,7 @@ package.preload["picker"] = package.preload["picker"] or function(...)
     local position = (_3fstart or 1)
     local size = #items
     local function _1_(direction)
+      _G.assert((nil ~= direction), "Missing argument direction on ./picker.fnl:27")
       position = (direction + position)
       local function _2_()
         local x = position
@@ -932,7 +933,8 @@ end
 local function on_load_file()
   local open_filename = mp.get_property("stream-open-filename", "")
   if (1 == open_filename:find("ytpb://")) then
-    return msg.info("ytpb URL detected, run hook", run_hook(open_filename))
+    msg.info("ytpb URL detected, run hook")
+    return run_hook(open_filename)
   else
     return nil
   end


### PR DESCRIPTION
These changes make it possible to keep the rewind history in the form of a binary search tree map, `RewindTreeMap <Timestamp, SegmentSequence>`, with key-value pairs of the ingestion walltime and sequence number values. 

Before, the latest sequence number always, at every rewind, requested and used as a reference.  With these changes, the reference is selected from the search tree map so that its timestamp (key) is closest to the target date.

This allows to minimize the number of segment locate steps (to be closer to the target sequence number and avoid gaps as possible) and helps to eliminate the need to constantly request for the reference sequence number.